### PR TITLE
Add a results api that gives back the winner

### DIFF
--- a/GiganticEmu.Agent/Controllers/LegacyApiController.cs
+++ b/GiganticEmu.Agent/Controllers/LegacyApiController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using GiganticEmu.Shared;
 using GiganticEmu.Shared.LegacyApi;
@@ -123,5 +124,31 @@ public class LegacyApiController : ControllerBase
             Timestamp = req.Timestamp,
             Events = new object[0],
         });
+    }
+    
+    [HttpPost("result")]
+    [Produces("application/json")]
+    public async Task<IActionResult> PostResult(ResultRequest req)
+    {
+        try
+        {
+            var logManager = new LogManager(req.Id);
+            if (logManager.IsRecent())
+            {
+                return Ok(new ResultResponse()
+                {
+                    Winner = logManager.GetWinner()
+                });
+            }
+            else
+            {
+                return BadRequest();
+            }
+        }
+        catch (FileNotFoundException)
+        {
+            return BadRequest();
+        }
+
     }
 }

--- a/GiganticEmu.Agent/LogManager.cs
+++ b/GiganticEmu.Agent/LogManager.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Globalization;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using GiganticEmu.Shared;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace GiganticEmu.Agent;
+
+public class LogManager
+{
+    private static Regex RE_WINNER = new Regex(@"(?<=ScriptLog: \(RXPAWN_)(NAGA|GRIFFIN)(?=_CONTENT_0\) RXPAWN::DYING:DESTROYED)", RegexOptions.Compiled | RegexOptions.Multiline);
+    private static Regex RE_IF_LOG_CLOSE = new Regex(@"^\[\d+: [0-9\.]+\] Log: Log file closed, \d{2}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2}", RegexOptions.Compiled | RegexOptions.Multiline);
+    
+    private readonly int _port;
+    private readonly string _logPath;
+    private readonly string _content;
+
+    public LogManager(int port)
+    {
+        _port = port;
+        _logPath = Path.GetFullPath(Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "My Games", "Gigantic", "RxGame", "Logs", $"GiganticEmu.Agent.{_port}.log"));
+        
+        using (var fs = new FileStream(_logPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+        {
+            using (var sr = new StreamReader(fs)) 
+            {
+                _content = sr.ReadToEnd();
+            }
+        }
+    }
+    
+    public bool IsRecent()
+    {
+        if (RE_IF_LOG_CLOSE.Matches(_content).Count != 0)
+        {
+            var logLength = _content.Length;
+            var time = _content.Substring(logLength-19, 17);
+            var dateTime = DateTime.Parse(time, CultureInfo.CurrentCulture);
+            return DateTime.Now.Subtract(dateTime).TotalSeconds <= 300;
+        }
+        else
+        {
+            return true;
+        }
+    }
+
+    public string? GetWinner()
+    {
+        var matches = RE_WINNER.Matches(_content);
+        if (matches.Count != 0) {
+            return matches[0].Value == "NAGA" ? "GRIFFIN" : "NAGA";
+        }
+        else {
+            return null;
+        }
+    }
+}

--- a/GiganticEmu.Shared/LegacyAPI/ResultRequest.cs
+++ b/GiganticEmu.Shared/LegacyAPI/ResultRequest.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace GiganticEmu.Shared.LegacyApi
+{
+    public record ResultRequest
+    {
+        [JsonPropertyName("id")]
+        public int Id { get; init; } = default!;
+    }
+}

--- a/GiganticEmu.Shared/LegacyAPI/ResultResponse.cs
+++ b/GiganticEmu.Shared/LegacyAPI/ResultResponse.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace GiganticEmu.Shared.LegacyApi
+{
+    public record ResultResponse
+    {
+        [JsonPropertyName("winner")]
+        public string Winner { get; init; } = default!;
+    }
+}


### PR DESCRIPTION
This adds an api endpoint at `/api/result` that currently only gives back the winning team. This implements a feature where once a game is done it will allow getting the results for 5 minuets or until a new game is started on that port. This should give time for people to press `GG` in fang while not being being too long for another game to accidentally go on. I also made this the endpoint `result` and not `winner` because some other data might want to be sent back (Like some automated tests or a simple anticheat, that would help automate admins having to look through the logs if they could just get all the info instantly). 